### PR TITLE
feat: add new code sample workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.speakeasy/reports
 /react-query
 /models
 /models/errors

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,10 +3,10 @@ id: 7bffa198-5d29-4efa-9942-d549cc832085
 management:
   docChecksum: 0573f979a398585490a8b196046afc66
   docVersion: 10.9.0
-  speakeasyVersion: 1.460.6
-  generationVersion: 2.484.4
-  releaseVersion: 0.13.4
-  configChecksum: 676c058be590ebb76aca5129131b0d99
+  speakeasyVersion: 1.461.0
+  generationVersion: 2.486.1
+  releaseVersion: 0.13.5
+  configChecksum: 2465446e04d994604803eb75d695edb4
   repoURL: https://github.com/apideck-libraries/sdk-typescript.git
   installationURL: https://github.com/apideck-libraries/sdk-typescript
   published: true

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -16,7 +16,7 @@ generation:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
 typescript:
-  version: 0.13.4
+  version: 0.13.5
   additionalDependencies:
     dependencies: {}
     devDependencies: {}

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,21 +1,21 @@
-speakeasyVersion: 1.460.6
+speakeasyVersion: 1.461.0
 sources:
     Apideck-OAS:
         sourceNamespace: apideck-oas
-        sourceRevisionDigest: sha256:8d36fdcc6da8642fb74016172fefd873660b1ccbac0d41e5e73491bac4d5331d
+        sourceRevisionDigest: sha256:5ab1cca297ecebab9e72dc6b2368d521af28cad264715fa729446b7ef8967f95
         sourceBlobDigest: sha256:4f88a753a09ecc6a10f5d56483b1c819d6d9170668b1c8a5046a84c438ba0284
         tags:
             - latest
-            - speakeasy-sdk-regen-1735811831
+            - speakeasy-sdk-regen-1735924078
             - 10.9.0
 targets:
     apideck:
         source: Apideck-OAS
         sourceNamespace: apideck-oas
-        sourceRevisionDigest: sha256:8d36fdcc6da8642fb74016172fefd873660b1ccbac0d41e5e73491bac4d5331d
+        sourceRevisionDigest: sha256:5ab1cca297ecebab9e72dc6b2368d521af28cad264715fa729446b7ef8967f95
         sourceBlobDigest: sha256:4f88a753a09ecc6a10f5d56483b1c819d6d9170668b1c8a5046a84c438ba0284
         codeSamplesNamespace: apideck-oas-typescript-code-samples
-        codeSamplesRevisionDigest: sha256:4459773d038127b26db09c03bb7b0b7dddfebc7d4532ef41af2231ede49be276
+        codeSamplesRevisionDigest: sha256:7a0ec2c84a86e5a833d9f38f5b805175dcc73933203b8bdb9abedf96d7fc4a9a
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: latest
@@ -25,6 +25,17 @@ workflow:
                 - location: https://ci-spec-unify.s3.eu-central-1.amazonaws.com/speakeasy-spec.yml
             registry:
                 location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas
+        Apideck-Sample-Docs:
+            inputs:
+                - location: https://ci-spec-unify.s3.eu-central-1.amazonaws.com/speakeasy-spec.yml
+            overlays:
+                - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas-typescript-code-samples
+                - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-csharp-code-samples
+                - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-go-code-samples
+                - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas-java-code-samples
+                - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-python-code-samples
+                - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-php-code-samples
+            output: apideck-oas-with-code-samples.yaml
     targets:
         apideck:
             target: typescript

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -6,6 +6,17 @@ sources:
             - location: https://ci-spec-unify.s3.eu-central-1.amazonaws.com/speakeasy-spec.yml
         registry:
             location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas
+    Apideck-Sample-Docs:
+        inputs:
+            - location: https://ci-spec-unify.s3.eu-central-1.amazonaws.com/speakeasy-spec.yml
+        overlays:
+            - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas-typescript-code-samples
+            - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-csharp-code-samples
+            - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-go-code-samples
+            - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas-java-code-samples
+            - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-python-code-samples
+            - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-php-code-samples
+        output: apideck-oas-with-code-samples.yaml
 targets:
     apideck:
         target: typescript

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -89,3 +89,13 @@ Based on:
 - [typescript v0.13.4] .
 ### Releases
 - [NPM v0.13.4] https://www.npmjs.com/package/@apideck/unify/v/0.13.4 - .
+
+## 2025-01-03 17:07:53
+### Changes
+Based on:
+- OpenAPI Doc  
+- Speakeasy CLI 1.461.0 (2.486.1) https://github.com/speakeasy-api/speakeasy
+### Generated
+- [typescript v0.13.5] .
+### Releases
+- [NPM v0.13.5] https://www.npmjs.com/package/@apideck/unify/v/0.13.5 - .

--- a/jsr.json
+++ b/jsr.json
@@ -2,7 +2,7 @@
 
 {
   "name": "@apideck/unify",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "exports": {
     ".": "./src/index.ts",    
     "./models/errors": "./src/models/errors/index.ts",    

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@apideck/unify",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@apideck/unify",
-      "version": "0.13.4",
+      "version": "0.13.5",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^7.7.1",
         "@typescript-eslint/parser": "^7.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apideck/unify",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "author": "Speakeasy",
   "main": "./index.js",
   "sideEffects": false,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -64,7 +64,7 @@ export function serverURLFromOptions(options: SDKOptions): URL | null {
 export const SDK_METADATA = {
   language: "typescript",
   openapiDocVersion: "10.9.0",
-  sdkVersion: "0.13.4",
-  genVersion: "2.484.4",
-  userAgent: "speakeasy-sdk/typescript 0.13.4 2.484.4 10.9.0 @apideck/unify",
+  sdkVersion: "0.13.5",
+  genVersion: "2.486.1",
+  userAgent: "speakeasy-sdk/typescript 0.13.5 2.486.1 10.9.0 @apideck/unify",
 } as const;


### PR DESCRIPTION
This pull request includes changes to the `.speakeasy/workflow.yaml` file to add a new source for Apideck sample documentation and code samples. The most important change is the addition of a new section under `sources` to include multiple code sample overlays for different programming languages.

Changes in `sources`:

* Added `Apideck-Sample-Docs` section with inputs and overlays for various programming languages including TypeScript, C#, Go, Java, Python, and PHP.