### PR TITLE
[DON'T MERGE] feat: overlay workflow

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -20,7 +20,7 @@ sources:
             - removeUnused: true
             - cleanup: true
         registry:
-            location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas-enhanced
+            location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas
     Apideck-Sample-Docs:
         inputs:
             - location: https://specs.apideck.com/accounting.yml
@@ -46,7 +46,7 @@ sources:
             - removeUnused: true
             - cleanup: true
         registry:
-            location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas-enhanced-with-code-samples
+            location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-with-code-samples
 targets:
     apideck:
         target: typescript

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -3,21 +3,50 @@ speakeasyVersion: latest
 sources:
     Apideck-OAS:
         inputs:
-            - location: https://ci-spec-unify.s3.eu-central-1.amazonaws.com/speakeasy-spec.yml
+            - location: https://specs.apideck.com/accounting.yml
+            - location: https://specs.apideck.com/ats.yml
+            - location: https://specs.apideck.com/connector.yml
+            - location: https://specs.apideck.com/crm.yml
+            - location: https://specs.apideck.com/ecommerce.yml
+            - location: https://specs.apideck.com/file-storage.yml
+            - location: https://specs.apideck.com/hris.yml
+            - location: https://specs.apideck.com/issue-tracking.yml
+            - location: https://specs.apideck.com/sms.yml
+            - location: https://specs.apideck.com/vault.yml
+            - location: https://specs.apideck.com/webhook.yml
+        overlays:
+            - location: https://ci-spec-unify.s3.eu-central-1.amazonaws.com/speakeasy-spec-overlay.yml
+        transformations:
+            - removeUnused: true
+            - cleanup: true
         registry:
-            location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas
+            location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas-enhanced
     Apideck-Sample-Docs:
         inputs:
-            - location: https://ci-spec-unify.s3.eu-central-1.amazonaws.com/speakeasy-spec.yml
+            - location: https://specs.apideck.com/accounting.yml
+            - location: https://specs.apideck.com/ats.yml
+            - location: https://specs.apideck.com/connector.yml
+            - location: https://specs.apideck.com/crm.yml
+            - location: https://specs.apideck.com/ecommerce.yml
+            - location: https://specs.apideck.com/file-storage.yml
+            - location: https://specs.apideck.com/hris.yml
+            - location: https://specs.apideck.com/issue-tracking.yml
+            - location: https://specs.apideck.com/sms.yml
+            - location: https://specs.apideck.com/vault.yml
+            - location: https://specs.apideck.com/webhook.yml
         overlays:
+            - location: https://ci-spec-unify.s3.eu-central-1.amazonaws.com/speakeasy-spec-overlay.yml
             - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas-typescript-code-samples
             - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-csharp-code-samples
             - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-go-code-samples
             - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas-java-code-samples
             - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-python-code-samples
             - location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-php-code-samples
+        transformations:
+            - removeUnused: true
+            - cleanup: true
         registry:
-            location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas-with-code-samples
+            location: registry.speakeasyapi.dev/apideck-k2o/apideck/apideck-oas-enhanced-with-code-samples
 targets:
     apideck:
         target: typescript


### PR DESCRIPTION
This pull request includes changes to the `.speakeasy/workflow.yaml` file to update the source locations, add new overlays and transformations, and modify the registry locations. These changes aim to enhance the workflow configuration by incorporating more specific API specifications and ensuring unused elements are removed and cleaned up.

Updates to source locations and overlays:

* Updated the `inputs` section to include multiple new API specification locations for both `Apideck-OAS` and `Apideck-Sample-Docs`.
* Added a new overlay location for both `Apideck-OAS` and `Apideck-Sample-Docs`.

Enhancements to transformations and registry:

* Added `removeUnused` and `cleanup` transformations to ensure unused elements are removed and cleaned up.
* Updated the `registry` location to point to enhanced versions for both `Apideck-OAS` and `Apideck-Sample-Docs`.